### PR TITLE
Change seal process to place MFA seed in common services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: help
 
 seal:
 	@echo "== Sealing Account =="
-	@docker run -v ${PWD}:/source -it --rm -e LASTPASS_USERNAME=${LASTPASS_USERNAME} -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} -w /source/seal-account ${DOCKER_IMAGE}:${DOCKER_TAG} /bin/bash create-sealed-user.sh
+	@docker run -v ${HOME}/.aws/:/root/.aws/ -v ${PWD}:/source -it --rm -w /source/seal-account ${DOCKER_IMAGE}:${DOCKER_TAG} /bin/bash create-sealed-user.sh
 
 package-lambda:
 	@echo "== Packaging Lambda =="

--- a/README.md
+++ b/README.md
@@ -8,7 +8,23 @@ have MFA enabled. The MFA seed is encrypted and saved to the parameter store of 
 In the event of emergency access users that have access to the account credentials in LastPass and have access to push
 to a specified GitHub repository can request to have the MFA seed emailed to them and gain access to the sealed account.
 
-### Initial Setup
+# Sealing Accounts
+
+To run this, you need:
+
+* A Premium LastPass account
+* Admin (IAM Full Access) Access to the account to be sealed
+* Docker
+* The ARN of the role to assume in the central account in order to push SSM params (output from terraform)
+* KMS Key ID of the KMS key in the central account used to encrypt MFA seed (output from terraform)
+
+## Seal an account
+
+To seal an account, just run `make seal` and follow the instructions.
+
+
+# Initial Setup
+
 1. Create a GitHub repository for making break-the-seal requests from
 1. Create a key pair for this repository and add the public key to the Deploy keys
 1. Create a folder for the environment <your_environment>
@@ -65,36 +81,3 @@ jobs:
         run: |
           aws s3 cp ${GITHUB_SHA::7}.zip s3://<AWS ACCOUNT NUMBER>-<BUCKET NAME>/${GITHUB_SHA::7}.zip
 ```
-
-
-
-### Sealing Accounts
-##### Pre-requisites:
-* A Premium LastPass account
-* Admin (IAM Full Access) Access to the account to be sealed
-* Docker installed
-* The ARN of the role to assume in the central account in order to push SSM params (output from terraform)
-* KMS Key ID of the KMS key in the central account used to encrypt MFA seed (output from terraform)
-
-
-###### Instructions:
-1. Obtain AWS credentials / temporary credentials (aws-azure-login, vaulted, aws-vault).
-2. Clone this repo.
-3. (Optional) if you are going to seal many accounts export the following variables so that you don't have to enter
-them each time.
-    *  `export LASTPASS_USERNAME=<mylastpass_username>` 
-    *  `export ROLE_ARN=<role to assume in central account>` 
-    *  `export KMS_KEY_ID=<kms key id - use the ID not the full ARN>` 
-3. From the root of this repo run `make seal`and follow the dialogue.
-
-    1. Enter The ARN of the role to assume in the central account (skipped if you have exported the variable)
-    1. Enter KMS Key ID of the KMS key to use in the central account (skipped if you have exported the variable)
-    1. Enter a Team Name - this is used to specify which LastPass folder to add the credentials to. You must have access
-     to write to this folder if it already exists. 
-    1. Enter your LastPass username (skipped if you have exported your LastPass username)
-    1. Enter your LastPass password
-    1. Enter your LastPass MFA
-
-Running `make seal` on an account that already has a user called `break.the.seal.user` will first delete the existing
-user and can be used to reseal an account once the seal has been broken
-    

--- a/seal-account/create-user.py
+++ b/seal-account/create-user.py
@@ -1,4 +1,3 @@
-
 """Usage: create-user.py TEAM_NAME ACCOUNT_ALIAS KMS_KEY_ID ROLE_ARN
 
 Provisions admin user and stores credentials.
@@ -10,63 +9,73 @@ Arguments:
 Options:
   -h --help
 """
-
 import boto3
 import pyotp
 import time
 from docopt import docopt
 
 arguments = docopt(__doc__)
-team_name = arguments['TEAM_NAME']
-account_alias = arguments['ACCOUNT_ALIAS']
 kms_key_id = arguments['KMS_KEY_ID']
 role_arn = arguments['ROLE_ARN']
 
 iam_client = boto3.client('iam', region_name='eu-west-1')
-account_id = boto3.client('sts').get_caller_identity()['Account']
 sts_client = boto3.client('sts')
-
-local_admin_user = iam_client.create_user(
-    UserName='break.the.seal.user',
-)
-
-virtual_mfa_device = iam_client.create_virtual_mfa_device(
-    VirtualMFADeviceName='break.the.seal.user.virtual.mfa.device'
-)
-print("Enabling MFA - takes 30s...")
-totp = pyotp.TOTP(virtual_mfa_device['VirtualMFADevice']['Base32StringSeed'])
-value_1 = totp.now()
-time.sleep(30)
-value_2 = totp.now()
-
-
-response = iam_client.enable_mfa_device(
-    UserName='break.the.seal.user',
-    SerialNumber=virtual_mfa_device['VirtualMFADevice']['SerialNumber'],
-    AuthenticationCode1=value_1,
-    AuthenticationCode2=value_2
-)
 
 assumed_role_object = sts_client.assume_role(
     RoleArn=role_arn,
     RoleSessionName='BreakTheSeal'
 )
-
-
-credentials=assumed_role_object['Credentials']
-ssm_client = boto3.client('ssm',
-                          region_name='eu-west-1',
-                          aws_access_key_id=credentials['AccessKeyId'],
-                          aws_secret_access_key=credentials['SecretAccessKey'],
-                          aws_session_token=credentials['SessionToken'],
-                          )
-response = ssm_client.put_parameter(
-    Name='/break-the-seal/'+account_id+'-mfa-seed',
-    Description='Seed for break.the.seal.user MFA',
-    Value=str(virtual_mfa_device['VirtualMFADevice']['Base32StringSeed']),
-    Type='SecureString',
-    KeyId=kms_key_id,
-    Overwrite=True
+credentials = assumed_role_object['Credentials']
+ssm_client = boto3.client(
+    'ssm',
+    region_name='eu-west-1',
+    aws_access_key_id=credentials['AccessKeyId'],
+    aws_secret_access_key=credentials['SecretAccessKey'],
+    aws_session_token=credentials['SessionToken'],
 )
 
 
+def create_user_with_mfa(username):
+    iam_client.create_user(UserName=username)
+    virtual_mfa_device = iam_client.create_virtual_mfa_device(
+        VirtualMFADeviceName="break.the.seal.user.virtual.mfa.device"
+    )
+
+    return virtual_mfa_device
+
+
+def enable_mfa(username, mfa_device):
+    totp = pyotp.TOTP(mfa_device['VirtualMFADevice']['Base32StringSeed'])
+
+    value_1 = totp.now()
+    time.sleep(30)
+    value_2 = totp.now()
+
+    iam_client.enable_mfa_device(
+        UserName=username,
+        SerialNumber=mfa_device['VirtualMFADevice']['SerialNumber'],
+        AuthenticationCode1=value_1,
+        AuthenticationCode2=value_2
+    )
+
+
+def publish_mfa_seed(seed: str):
+    account_id = boto3.client('sts').get_caller_identity()['Account']
+    ssm_client.put_parameter(
+        Name=f"/break-the-seal/{account_id}-mfa-seed",
+        Description=f'MFA Seed for break.the.seal.user in {account_id}',
+        Type='SecureString',
+        KeyId=kms_key_id,
+        Overwrite=True,
+        Value=seed,
+    )
+
+
+if __name__ == "__main__":
+    username = "break.the.seal.user"
+    mfa_device = create_user_with_mfa(username)
+
+    print("Enabling MFA - takes 30s...")
+    enable_mfa(username, mfa_device)
+
+    publish_mfa_seed(str(mfa_device['VirtualMFADevice']['Base32StringSeed']))

--- a/seal-account/requirements.txt
+++ b/seal-account/requirements.txt
@@ -1,4 +1,2 @@
 boto3==1.14.4
-docutils==0.15.2
 pyotp==2.3.0
-docopt==0.6.2


### PR DESCRIPTION
This change makes the MFA seed in common service's parameter store in stead of in the sealed account's store.